### PR TITLE
Quote regular expression correctly

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -327,7 +327,7 @@ version = int(versionString.replace('.', ""))
 if version < 10000:
     version = version * 1000
 
-frameworkExpression = re.compile("<TargetFramework>netcoreapp\d\.\d</TargetFramework>", re.M)
+frameworkExpression = re.compile(r"<TargetFramework>netcoreapp\d\.\d</TargetFramework>", re.M)
 
 rootPath = os.path.abspath(os.path.curdir)
 dotnetBunny = DotnetBunny(rootPath)


### PR DESCRIPTION
As a normal string, "\d" is interpreted by python as an escape sequence followed by "d". Use raw strings to indicate the slashes should be taken literally.