### PR TITLE
Fold in the logic behind the use of --packages-not-live flag

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -17,20 +17,6 @@ except:
     from urllib.request import urlopen
 
 
-def generateNuGetConfigContents(version):
-    gitBranch = "release/" + version
-    url = "https://raw.githubusercontent.com/dotnet/source-build/" + gitBranch + "/ProdConFeed.txt"
-    response = urlopen(url)
-    nuGetFeed = response.read().strip()
-    return """<?xml version="1.0" encoding="utf-8"?>
-<configuration>
- <packageSources>
-    <add key="prodcon" value="%s" />
- </packageSources>
-</configuration>
-
-""" % (nuGetFeed,)
-
 class DotnetBunny(object):
 
     class Test(object):
@@ -109,10 +95,10 @@ class DotnetBunny(object):
             testlog = ""
             errorCode = 1
 
-            if needsCustomNuGetConfig:
+            if nuGetConfig:
                 nuGetConfigLocation = os.path.join(path, "nuget.config")
                 if os.path.exists(nuGetConfigLocation):
-                    print("error: nugetconfig %s already exists " % (nuGetConfigLocation,))
+                    print("error: nugetconfig at %s already exists " % (nuGetConfigLocation,))
                     exit(2)
                 with open(nuGetConfigLocation, "w") as nugetConfig:
                     nugetConfig.write(nuGetConfig)
@@ -281,6 +267,46 @@ class DotnetBunny(object):
         shutil.rmtree("~/.templateengine", True)
 
 
+def getDotNetRuntimeVersion():
+    "Guess the latest runtime version for the default dotnet on the command line"
+    process = subprocess.Popen(["dotnet", "--list-runtimes"],
+                               stdout=subprocess.PIPE,
+                               universal_newlines=True)
+    errorCode = process.wait()
+    if errorCode:
+        return None
+    output = process.communicate()[0]
+    netCoreAppVersions = [line.split(" ")[1]
+                          for line in output.split("\n")
+                          if line.startswith("Microsoft.NETCore.App")]
+    latest = sorted(netCoreAppVersions)[-1]
+    return latest
+
+def nugetPackagesAreLive(version):
+    "True if the Microsoft.NETCore.App packages are available on nuget.org for the given version."
+    # See https://docs.microsoft.com/en-us/nuget/api/search-autocomplete-service-resource
+    url = "https://api-v2v3search-0.nuget.org/autocomplete?id=microsoft.netcore.app&prerelease=true"
+    response = urlopen(url)
+    jsonResponse = json.load(response)
+    found = version in jsonResponse["data"]
+    return found
+
+def getProdConFeedUrl(branchName):
+    "Find the prodcon url for the given release branch of github.com/dotnet/source-build."
+    url = "https://raw.githubusercontent.com/dotnet/source-build/" + branchName + "/ProdConFeed.txt"
+    response = urlopen(url)
+    return response.read().strip()
+
+def generateNuGetConfigContentsForFeed(url):
+    return """<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <add key="prodcon" value="%s" />
+ </packageSources>
+</configuration>
+
+""" % (url,)
+
 def getKnownPlatforms():
     platforms = []
     platforms.append("rhel")
@@ -345,7 +371,6 @@ debug = False
 platforms = identifyPlatform()
 knownPlatforms = getKnownPlatforms()
 logDirectory = os.getcwd()
-needsCustomNuGetConfig = False
 nuGetConfig = ""
 
 for arg in sys.argv:
@@ -376,10 +401,6 @@ for arg in sys.argv:
 
     if arg == "-d":
         debug = True
-        continue
-
-    if arg == "--packages-not-live":
-        needsCustomNuGetConfig = True
         continue
 
     if arg.startswith("-l="):
@@ -418,8 +439,15 @@ if version < 10000:
 
 frameworkExpression = re.compile(r"<TargetFramework>netcoreapp\d\.\d</TargetFramework>", re.M)
 
-if needsCustomNuGetConfig:
-    nuGetConfig = generateNuGetConfigContents(majorMinorString)
+latestDotNetRuntimeVersion = getDotNetRuntimeVersion()
+if latestDotNetRuntimeVersion and not nugetPackagesAreLive(latestDotNetRuntimeVersion):
+    branchName = "release/" + majorMinorString
+    prodConUrl = getProdConFeedUrl(branchName)
+    message = "Packages for runtime version %s are not live on nuget.org, using prodcon nuget repository %s\n" \
+        % (latestDotNetRuntimeVersion, prodConUrl)
+    print(message)
+    logfile.writelines(message)
+    nuGetConfig = generateNuGetConfigContentsForFeed(prodConUrl)
     if debug:
         print(nuGetConfig)
 


### PR DESCRIPTION
Make the script smarter so it automatically can do the right thing without needing a `--packages-not-live` flag.

The logic is:

1. Look for the version of Microsoft.NETCore.App that will be tested

2. If it's available on nuget.org, nothing else to do. All tests will use nuget.org by default already.

3. If the version of Microsoft.NETCore.App is not available on nuget.org, then use the prodcon nuget feed.