### PR TITLE
Decode prodcon URL from bytes to string

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -301,7 +301,7 @@ def getProdConFeedUrl(branchName):
     "Find the prodcon url for the given release branch of github.com/dotnet/source-build."
     url = "https://raw.githubusercontent.com/dotnet/source-build/" + branchName + "/ProdConFeed.txt"
     response = urlopen(url)
-    return response.read().strip()
+    return response.read().strip().decode('utf-8')
 
 def generateNuGetConfigContentsForFeeds(urls):
     sources = '\n    '.join('<add key="%s" value="%s" />' % (index, url) for index, url in enumerate(urls))


### PR DESCRIPTION
On (at least) recent versions of python3, opening a url and reading
the contents of the reponse returns bytes, not a string. If we pass
along those bytes to later parts of the code, we end up with a url
that gets written to the nuget.config as a string representation of
the bytes: b'foo'. The nuget confg file then looks like this:

    <add key="0" value="b'https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20190214-01/final/index.json'" />

.NET Core SDK then parses this as a local/relative file path. And
everything breaks.

I have tested this conversion with both python2 (2.7) and
python3 (3.7); decode() works correctly in both.