### PR TITLE
Enable unsafe blocks for tests with 1.x

### DIFF
--- a/project10.json
+++ b/project10.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
+    "allowUnsafe": true,
     "warningsAsErrors": true,
     "debugType": "portable",
     "emitEntryPoint": true

--- a/project10xunit.json
+++ b/project10xunit.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
+    "allowUnsafe": true,
     "warningsAsErrors": true,
     "debugType": "portable"
   },

--- a/project11.json
+++ b/project11.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
+    "allowUnsafe": true,
     "warningsAsErrors": true,
     "debugType": "portable",
     "emitEntryPoint": true

--- a/project11xunit.json
+++ b/project11xunit.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
+    "allowUnsafe": true,
     "warningsAsErrors": true,
     "debugType": "portable"
   },


### PR DESCRIPTION
Add a switch to the various project.json files to allow `/unsafe` to be passed to the compiler.