### PR TITLE
Fix versions parsing for strings with '1.x'-style

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -32,11 +32,11 @@ class DotnetBunny(object):
             self.type = config["type"]
             self.anyMinor = config["version"].split('.')[1] == "x"
             if self.anyMinor:
-                self.version = int(config["version"].split('.')[0])
+                self.version = int(config["version"].split('.')[0] + '0')
             else:
                 self.version = int(config["version"].replace('.', ""))
-                if self.version < 10000:
-                    self.version = self.version * 1000
+            if self.version < 10000:
+                self.version = self.version * 1000
 
             self.versionSpecific = config["versionSpecific"]
             self.platformBlacklist = config["platformBlacklist"]


### PR DESCRIPTION
Before this change, we parse the string "2.1" to the raw version-as-int 21000 but only parse "2.x" as the version-as-int 2.

Instead parse "2.x" as: '2.0' -> '20' -> 20000.