### PR TITLE
Assert test name and directory name match

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -28,6 +28,12 @@ class DotnetBunny(object):
             config = json.load(open(configPath))
 
             self.name = config["name"]
+            directory_name = os.path.basename(os.path.dirname(configPath))
+            if self.name != directory_name:
+                print("error: mismatch in directory name '%s' vs test name '%s' in '%s'" %
+                    (directory_name, self.name, configPath))
+                exit(3)
+
             self.enabled = config["enabled"]
             self.type = config["type"]
             self.anyMinor = config["version"].split('.')[1] == "x"


### PR DESCRIPTION
We have a couple of examples of test names and directory names being
slightly different. This runner can show the (incorrect) test name,
misleading the user about where the issue is.

So just fail early and outright if we run into a test with this issue.
This will force people to fix the tests.