### PR TITLE
Fix running with just the major/minor version too

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -505,8 +505,7 @@ logfilename = "logfile"
 logfile = open(os.path.join(logDirectory, logfilename) + ".log", "w")
 logfile.writelines("\n\n(\\_/)\n(^_^)\n@(\")(\")\n\n")
 
-match = re.search(r'^\d\.\d\.\d+', sys.argv[1])
-#match = re.search("^[0-9.]+", sys.argv[1])
+match = re.search(r'^\d\.\d(?:\.\d+)?', sys.argv[1])
 versionString = match.group(0)
 versionArray = versionString.split('.')
 majorMinorString = versionArray[0] + "." + versionArray[1]


### PR DESCRIPTION
This script is invoked with either the full version (2.1.100) or the major/minor version (2.1). But commit 3570e57f changed this and now the script only works when invoked with the full version. Fix that.