### PR TITLE
Make the version equality check more robust.

### DIFF
--- a/Turkey/Version.cs
+++ b/Turkey/Version.cs
@@ -120,7 +120,18 @@ namespace Turkey
 
         public static bool operator >=(Version x, Version y) { return CompareTo(x, y) >= 0; }
 
-        public static bool operator ==(Version x, Version y) { return CompareTo(x, y) == 0; }
+        public static bool operator ==(Version x, Version y)
+        {
+            if (object.ReferenceEquals(x, null) && object.ReferenceEquals(y, null))
+            {
+                return true;
+            }
+            else if (object.ReferenceEquals(x, null) || object.ReferenceEquals(y, null))
+            {
+                return false;
+            }
+            return CompareTo(x, y) == 0;
+        }
 
         public static bool operator !=(Version x, Version y) { return CompareTo(x, y) != 0; }
 


### PR DESCRIPTION
This protects against comparing versions to null, where previously Version.CompareTo always assumed the versions being checked would be non-null.

Previously this was null-ref'ing for me on https://github.com/redhat-developer/dotnet-bunny/blob/85ad96ac638ca0dfd1caea49632f679008e00e19/Turkey/DotNet.cs#L75.