### PR TITLE
Document release process and remove duplicate scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,53 @@ Some notes for writing tests:
 
     WARNING: foo bar baz
 
+# Releasing
+
+1. Tag the release
+
+       $ git tag -a v# --sign
+
+   Replease `#` with the real release version. Generally, use the previous
+   release version + 1. For example, if the last tag was `v99`, use `v100`.
+
+   This produces a signed and annotated tag. Feel free to add details about the
+   release to the annotation.
+
+   Signing requires a gpg key. If you don't have one, you can omit `--sign`.
+
+2. Use `make publish` to genereate executables ready for releasing
+
+   The generated executables are placed in the top-level `bin` directory.  They
+   are stand-alone and include correct version information:
+
+       $ make publish
+       $ ./bin/turkey --version
+       4-df8f520
+
+   Only build the binaries after tagging. That makes sure the version string in
+   the binary is updated correctly.
+
+3. Push the tags to GitHub
+
+       $ git push --tags remote-name
+
+4. Create a release in GitHub
+
+   1. Go to https://github.com/redhat-developer/dotnet-bunny/releases/new
+
+   2. Select the tag created in step 1
+
+   3. Name the release along the lines of "Version #" where, replacing "#" with
+      the actual version
+
+   3. Write release notes
+
+   4. Attach the `turkey` binary from step 2 to the GitHub release
+
+      Many tools use `wget
+      https://github.com/redhat-developer/dotnet-bunny/releases/latest/download/turkey`
+      to get the latest release. Don't break them.
+
 # TODO
 
 - Do not modify original source files for xunit tests

--- a/Turkey/Turkey.csproj
+++ b/Turkey/Turkey.csproj
@@ -4,9 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <PublishSingleFile>true</PublishSingleFile>
-    <PublishTrimmed>true</PublishTrimmed>
-    <UseAppHost>true</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/publish.sh
+++ b/publish.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-rm -rf Turkey/bin Turkey/obj
-pushd Turkey
-dotnet publish -r linux-x64 -c Release --self-contained true
-popd
-mv Turkey/bin/Release/netcoreapp3.1/linux-x64/publish/Turkey Turkey/bin/Release/netcoreapp3.1/linux-x64/publish/turkey
-ls -lah Turkey/bin/Release/netcoreapp3.1/linux-x64/publish/
-


### PR DESCRIPTION
The recently added `publish.sh` produces executables that do not container complete version information:

```
$ wget https://github.com/redhat-developer/dotnet-bunny/releases/latest/download/turkey
$ chmod +x ./turkey 
$ ./turkey --version
1.0.0
```

Using the version built by `make publish` includes tag/commit information:

```
$ make publish
$ ./bin/turkey --version
4-df8f520
```

The version should have been `5-df8f520` here, but the `v5` tag was not an annotated tag.