### PR TITLE
Fix dotnet-bunny to run against .NET 5.0

### DIFF
--- a/Turkey/SourceBuild.cs
+++ b/Turkey/SourceBuild.cs
@@ -18,6 +18,11 @@ namespace Turkey
         public Task<string> GetProdConFeedAsync(Version version)
         {
             var branchName = "release/" + version.MajorMinor;
+            // FIXME: hack to treat 5.0 as special for now
+            if (version.Major == 5)
+            {
+                branchName = "master";
+            }
             return GetProdConFeedAsync(branchName);
         }
 


### PR DESCRIPTION
This solution is a bit of a hack, but since source-build is planned to go away in 5.0, this should be okay for now.