### PR TITLE
Missing ignoredRIDs in a test is okay

### DIFF
--- a/Turkey.Tests/TestParserTest.cs
+++ b/Turkey.Tests/TestParserTest.cs
@@ -125,6 +125,26 @@ namespace Turkey.Tests
             Assert.Equal(expectedToRun, shouldRun);
         }
 
+        [Fact]
+        public void MissingIgnoredRIDsIsOkay()
+        {
+            TestParser parser = new TestParser();
+            SystemUnderTest system = new SystemUnderTest(
+                runtimeVersion: Version.Parse("2.1"),
+                sdkVersion: null,
+                platformIds: new string[] { "linux" }.ToList());
+            TestDescriptor test = new TestDescriptor()
+            {
+                Enabled = true,
+                RequiresSdk = false,
+                Version = "2.1",
+                IgnoredRIDs = null,
+            };
+
+            var shouldRun = parser.ShouldRunTest(system, test);
+
+            Assert.Equal(true, shouldRun);
+        }
         [Theory]
         [InlineData(new string[] { "linux" }, new string[] { }, true)]
         [InlineData(new string[] { "linux" }, new string[] { "fedora" }, true)]

--- a/Turkey/TestParser.cs
+++ b/Turkey/TestParser.cs
@@ -58,13 +58,16 @@ namespace Turkey
                 return false;
             }
 
-            var skipped = system.CurrentPlatformIds
-                .Where(rid => test.IgnoredRIDs.Contains(rid))
-                .Any();
-
-            if (skipped)
+            if (test.IgnoredRIDs != null)
             {
-                return false;
+                var skipped = system.CurrentPlatformIds
+                    .Where(rid => test.IgnoredRIDs.Contains(rid))
+                    .Any();
+
+                if (skipped)
+                {
+                    return false;
+                }
             }
 
             return true;


### PR DESCRIPTION
Treat it the same wasy as if it was missing: the test should not be ignored on the current platform.