### PR TITLE
Replace `net5.0` TargetFramework in csproj too

### DIFF
--- a/Turkey.Tests/CsprojCompatibilityPatcherTest.cs
+++ b/Turkey.Tests/CsprojCompatibilityPatcherTest.cs
@@ -1,0 +1,36 @@
+using System;
+
+using Turkey;
+
+using Xunit;
+
+namespace Turkey.Tests
+{
+    public class CsprojCompatibilityPatcherTest
+    {
+        [Theory]
+        [InlineData("netcoreapp1.0", "2.1", "netcoreapp2.1")]
+        [InlineData("netcoreapp2.1", "3.1", "netcoreapp3.1")]
+        [InlineData("netcoreapp3.1", "3.1", "netcoreapp3.1")]
+        [InlineData("net5.0", "3.1", "netcoreapp3.1")]
+        [InlineData("net5.0", "2.1", "netcoreapp2.1")]
+        public void TargetFrameworksAreReplacedCorrectly(string currentTfm, string runtimeVersion, string expectedTfm)
+        {
+            Version newRuntimeVersion = Version.Parse(runtimeVersion);
+            string csproj = $@"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>{currentTfm}</TargetFramework>
+  </PropertyGroup>
+
+</Project>";
+            string patched = new CsprojCompatibilityPatcher().Patch(csproj, newRuntimeVersion);
+            Assert.Contains(expectedTfm, patched);
+            if (currentTfm != expectedTfm)
+            {
+                Assert.DoesNotContain(currentTfm, patched);
+            }
+        }
+    }
+}

--- a/Turkey/CsprojCompatibilityPatcher.cs
+++ b/Turkey/CsprojCompatibilityPatcher.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Turkey
+{
+    public class CsprojCompatibilityPatcher
+    {
+        public string Patch(string originalCsprojContents, Version newRuntime)
+        {
+            var pattern = @"<TargetFramework>net(?:coreapp)?\d\.\d+</TargetFramework>";
+            var versionString = newRuntime.MajorMinor;
+            string replacement = null;
+            if (newRuntime.Major < 4)
+            {
+                replacement = $"<TargetFramework>netcoreapp{versionString}</TargetFramework>";
+            }
+            else
+            {
+                replacement = $"<TargetFramework>net{versionString}</TargetFramework>";
+            }
+            var output = Regex.Replace(originalCsprojContents, pattern, replacement);
+
+            return output;
+        }
+
+    }
+
+}

--- a/Turkey/Test.cs
+++ b/Turkey/Test.cs
@@ -163,16 +163,8 @@ namespace Turkey
             return new PartialResult(true, "", "");
         }
 
-        private string UpdateCsprojContents(string contents)
-        {
-            var pattern = "<TargetFramework>netcoreapp\\d\\.\\d+</TargetFramework>";
-            var versionString = this.SystemUnderTest.RuntimeVersion.MajorMinor;
-            var replacement = $"<TargetFramework>netcoreapp{versionString}</TargetFramework>";
-
-            var output = Regex.Replace(contents, pattern, replacement);
-
-            return output;
-        }
+        private string UpdateCsprojContents(string contents) =>
+            new CsprojCompatibilityPatcher().Patch(contents, this.SystemUnderTest.RuntimeVersion);
 
         protected abstract Task<TestResult> InternalRunAsync(CancellationToken cancellationToken);
 


### PR DESCRIPTION
When running an xunit project, we patch the TargetFramework in the csproj file to make sure it targets the runtime we are trying to test. That's currently implemented for TargetFramework values matching the regex `netcoreapp\d\.\d`.  Extend the regex to match `net\d\.\d` as well.

This fixes the first issue caught in https://github.com/redhat-developer/dotnet-regular-tests/pull/131