### PR TITLE
Update environments tested via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,19 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      fail-fast: false
       matrix:
         container_image:
-          - fedora:33
-          - fedora:32
-          - fedora:rawhide
+          - registry.fedoraproject.org/fedora:33
+          - registry.fedoraproject.org/fedora:34
+          - registry.fedoraproject.org/fedora:35
           - registry.access.redhat.com/ubi8
         dotnet_version:
           - "3.1"
 
     container:
       image: ${{ matrix.container_image }}
+      options: --security-opt seccomp=unconfined
 
     steps:
       - name: Install build dependencies
@@ -44,17 +46,19 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      fail-fast: false
       matrix:
         container_image:
-          - fedora:33
-          - fedora:32
-          - fedora:rawhide
+          - registry.fedoraproject.org/fedora:33
+          - registry.fedoraproject.org/fedora:34
+          - registry.fedoraproject.org/fedora:35
           - registry.access.redhat.com/ubi8
         dotnet_version:
           - "3.1"
 
     container:
       image: ${{ matrix.container_image }}
+      options: --security-opt seccomp=unconfined
 
     steps:
       - name: Install build dependencies


### PR DESCRIPTION
Add newer Fedora versions, remove Fedora 32 (EOL). Add CentOS Stream 9 which reflects the RHEL 9 release).

Also, run all tests to completion, instead of failing early if a single check fails.