### PR TITLE
Add support for filtering out enviornment variables in tests

### DIFF
--- a/Samples/PassingBashTestWithEnvironmentVariables/test.json
+++ b/Samples/PassingBashTestWithEnvironmentVariables/test.json
@@ -1,0 +1,12 @@
+{
+  "name": "PassingBashTestWithEnvironmentVariables",
+  "enabled": true,
+  "requiresSdk": true,
+  "version": "1.0",
+  "versionSpecific": false,
+  "type": "bash",
+  "cleanup": true,
+  "ignoredRIDs":[
+  ]
+}
+

--- a/Samples/PassingBashTestWithEnvironmentVariables/test.sh
+++ b/Samples/PassingBashTestWithEnvironmentVariables/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+env
+
+if [[ -n "${OPENSSL_CONF}" ]]; then
+    echo "error: OPENSSL_CONF should never be set"
+    exit 1
+fi

--- a/Samples/PassingXUnitTestWithEnvironmentVariables/PassingXUnitTestWithEnvironmentVariables.cs
+++ b/Samples/PassingXUnitTestWithEnvironmentVariables/PassingXUnitTestWithEnvironmentVariables.cs
@@ -1,0 +1,14 @@
+using System;
+using Xunit;
+
+namespace Samples
+{
+    public class PassingXUnitTestWithEnvironmentVariables
+    {
+        [Fact]
+        public void Test1()
+        {
+            Assert.Null(Environment.GetEnvironmentVariable("OPENSSL_CONF"));
+        }
+    }
+}

--- a/Samples/PassingXUnitTestWithEnvironmentVariables/PassingXUnitTestWithEnvironmentVariables.csproj
+++ b/Samples/PassingXUnitTestWithEnvironmentVariables/PassingXUnitTestWithEnvironmentVariables.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+</Project>

--- a/Samples/PassingXUnitTestWithEnvironmentVariables/test.json
+++ b/Samples/PassingXUnitTestWithEnvironmentVariables/test.json
@@ -1,0 +1,12 @@
+{
+  "name": "PassingXUnitTestWithEnvironmentVariables",
+  "enabled": true,
+  "requiresSdk": true,
+  "version": "1.0",
+  "versionSpecific": false,
+  "type": "xunit",
+  "cleanup": true,
+  "ignoredRIDs":[
+  ]
+}
+

--- a/Turkey.Tests/EnvironmentVariableSanitizerTest.cs
+++ b/Turkey.Tests/EnvironmentVariableSanitizerTest.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Xunit;
+
+namespace Turkey.Tests
+{
+    public class EnvironmentVariableSanitizerTest
+    {
+        [Theory]
+        // TODO enable these too
+        // [InlineData("ASPNETCORE_URLS")]
+        // [InlineData("COREHOST_TRACE")]
+        // [InlineData("DOTNET_FOO_BAR")]
+        // [InlineData("DOTNET_ROLL_FORWARD")]
+        // [InlineData("DOTNET_RUNTIME_ID")]
+        // [InlineData("DOTNET_STARTUP_HOOKS")]
+        // [InlineData("NUGET_PACKAGES")]
+        [InlineData("OPENSSL_CONF")]
+        public void EnvironmentVariablesAreRemoved(string name)
+        {
+            var environment = new Dictionary<string, string>()
+            {
+                { name, "foobar" },
+            };
+
+            var sanitizer = new EnvironmentVariableSanitizer();
+            var result = sanitizer.SanitizeEnvironmentVariables(environment);
+
+            Assert.DoesNotContain(name, result.Keys);
+        }
+
+        [InlineData("DOTNET_ROOT")]
+        [InlineData("DOTNET_CLI_TELEMETRY_OPTOUT")]
+        [InlineData("PATH")]
+        [InlineData("USER")]
+        [InlineData("HOME")]
+        public void EnvironmentVariablesAreKept(string name)
+        {
+            var environment = new Dictionary<string, string>()
+            {
+                { name, "foobar" },
+            };
+
+            var sanitizer = new EnvironmentVariableSanitizer();
+            var result = sanitizer.SanitizeEnvironmentVariables(environment);
+
+            Assert.Contains(name, result.Keys);
+
+        }
+    }
+}

--- a/Turkey.Tests/TestParserTest.cs
+++ b/Turkey.Tests/TestParserTest.cs
@@ -12,7 +12,7 @@ namespace Turkey.Tests
         public void DisabledTestShouldBeSkipped()
         {
             TestParser parser = new TestParser();
-            SystemUnderTest system = new SystemUnderTest(null, null, null);
+            SystemUnderTest system = new SystemUnderTest(null, null, null, null);
             TestDescriptor test = new TestDescriptor()
             {
                 Enabled = false,
@@ -41,7 +41,8 @@ namespace Turkey.Tests
             SystemUnderTest system = new SystemUnderTest(
                 runtimeVersion: Version.Parse(version),
                 sdkVersion: null,
-                platformIds: new List<string>());
+                platformIds: new List<string>(),
+                environmentVariables: null);
 
             TestDescriptor test = new TestDescriptor()
             {
@@ -75,7 +76,8 @@ namespace Turkey.Tests
             SystemUnderTest system = new SystemUnderTest(
                 runtimeVersion: Version.Parse(version),
                 sdkVersion: null,
-                platformIds: new List<string>());
+                platformIds: new List<string>(),
+                environmentVariables: null);
             TestDescriptor test = new TestDescriptor()
             {
                 Enabled = true,
@@ -111,7 +113,8 @@ namespace Turkey.Tests
             SystemUnderTest system = new SystemUnderTest(
                 runtimeVersion: Version.Parse(version),
                 sdkVersion: null,
-                platformIds: new List<string>());
+                platformIds: new List<string>(),
+                environmentVariables: null);
             TestDescriptor test = new TestDescriptor()
             {
                 Enabled = true,
@@ -132,7 +135,8 @@ namespace Turkey.Tests
             SystemUnderTest system = new SystemUnderTest(
                 runtimeVersion: Version.Parse("2.1"),
                 sdkVersion: null,
-                platformIds: new string[] { "linux" }.ToList());
+                platformIds: new string[] { "linux" }.ToList(),
+                environmentVariables: null);
             TestDescriptor test = new TestDescriptor()
             {
                 Enabled = true,
@@ -159,7 +163,8 @@ namespace Turkey.Tests
             SystemUnderTest system = new SystemUnderTest(
                 runtimeVersion: Version.Parse("2.1"),
                 sdkVersion: null,
-                platformIds: currentPlatforms.ToList());
+                platformIds: currentPlatforms.ToList(),
+                environmentVariables: null);
             TestDescriptor test = new TestDescriptor()
             {
                 Enabled = true,
@@ -183,7 +188,8 @@ namespace Turkey.Tests
             SystemUnderTest system = new SystemUnderTest(
                 runtimeVersion: Version.Parse("3.1"),
                 sdkVersion: Version.Parse(sdkVersion),
-                platformIds: new List<string>());
+                platformIds: new List<string>(),
+                environmentVariables: null);
             TestDescriptor test = new TestDescriptor()
             {
                 Enabled = true,

--- a/Turkey/BashTest.cs
+++ b/Turkey/BashTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -36,6 +37,13 @@ namespace Turkey
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
+
+            startInfo.EnvironmentVariables.Clear();
+            foreach (var (key, value) in SystemUnderTest.EnvironmentVariables)
+            {
+                startInfo.EnvironmentVariables.Add(key, value);
+            }
+
             standardOutputWriter.WriteLine($"Executing {startInfo.FileName} with arguments {startInfo.Arguments} in working directory {startInfo.WorkingDirectory}");
             using (Process p = Process.Start(startInfo))
             {

--- a/Turkey/DotNet.cs
+++ b/Turkey/DotNet.cs
@@ -93,7 +93,7 @@ namespace Turkey
             }
         }
 
-        public static async Task<ProcessResult> BuildAsync(DirectoryInfo workingDirectory, CancellationToken token)
+        public static async Task<ProcessResult> BuildAsync(DirectoryInfo workingDirectory, IReadOnlyDictionary<string, string> environment, CancellationToken token)
         {
             var arguments = new string[]
             {
@@ -102,21 +102,21 @@ namespace Turkey
                 "-p:UseSharedCompilation=false",
                 "-m:1",
             };
-            var result = await RunDotNetCommandAsync(workingDirectory, arguments, token);
+            var result = await RunDotNetCommandAsync(workingDirectory, arguments, environment, token);
             return result;
         }
 
-        public static async Task<ProcessResult> RunAsync(DirectoryInfo workingDirectory, CancellationToken token)
+        public static async Task<ProcessResult> RunAsync(DirectoryInfo workingDirectory, IReadOnlyDictionary<string, string> environment, CancellationToken token)
         {
-            return await RunDotNetCommandAsync(workingDirectory, new string[] { "run", "--no-restore", "--no-build"} , token);
+            return await RunDotNetCommandAsync(workingDirectory, new string[] { "run", "--no-restore", "--no-build"} , environment, token);
         }
 
-        public static async Task<ProcessResult> TestAsync(DirectoryInfo workingDirectory, CancellationToken token)
+        public static async Task<ProcessResult> TestAsync(DirectoryInfo workingDirectory, IReadOnlyDictionary<string, string> environment, CancellationToken token)
         {
-            return await RunDotNetCommandAsync(workingDirectory, new string[] { "test", "--no-restore", "--no-build"} , token);
+            return await RunDotNetCommandAsync(workingDirectory, new string[] { "test", "--no-restore", "--no-build"} , environment, token);
         }
 
-        private static async Task<ProcessResult> RunDotNetCommandAsync(DirectoryInfo workingDirectory, string[] commands, CancellationToken token)
+        private static async Task<ProcessResult> RunDotNetCommandAsync(DirectoryInfo workingDirectory, string[] commands, IReadOnlyDictionary<string, string> environment, CancellationToken token)
         {
             var arguments = string.Join(" ", commands);
             ProcessStartInfo startInfo = new ProcessStartInfo()
@@ -127,6 +127,12 @@ namespace Turkey
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
+
+            startInfo.EnvironmentVariables.Clear();
+            foreach (var (key, value) in environment)
+            {
+                startInfo.EnvironmentVariables.Add(key, value);
+            }
 
             using (var process = Process.Start(startInfo))
             {

--- a/Turkey/EnvironmentVariableSanitizer.cs
+++ b/Turkey/EnvironmentVariableSanitizer.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Turkey
+{
+    public class EnvironmentVariableSanitizer
+    {
+        private readonly List<string> ToFilter = new List<string>()
+        {
+            "OPENSSL_CONF",
+        };
+
+        public Dictionary<string, string> SanitizeCurrentEnvironmentVariables()
+        {
+            return SanitizeEnvironmentVariables(Environment.GetEnvironmentVariables());
+        }
+
+        public Dictionary<string, string> SanitizeEnvironmentVariables(IDictionary environmentVariables)
+        {
+            var result = new Dictionary<string, string>();
+
+            foreach (DictionaryEntry entry in environmentVariables)
+            {
+                if (ToFilter.Contains((string)entry.Key))
+                {
+                    continue;
+                }
+
+                result.Add((string)entry.Key, (string)entry.Value);
+            }
+
+            return result;
+        }
+    }
+}

--- a/Turkey/Program.cs
+++ b/Turkey/Program.cs
@@ -100,14 +100,19 @@ namespace Turkey
             List<string> platformIds = new PlatformId().CurrentIds;
             Console.WriteLine($"Current platform is: {string.Join(", ", platformIds)}");
 
+            var sanitizer = new EnvironmentVariableSanitizer();
+            var envVars = sanitizer.SanitizeCurrentEnvironmentVariables();
+
             SystemUnderTest system = new SystemUnderTest(
                 runtimeVersion: dotnet.LatestRuntimeVersion,
                 sdkVersion: dotnet.LatestSdkVersion,
-                platformIds: platformIds
+                platformIds: platformIds,
+                environmentVariables: envVars
             );
 
             Version packageVersion = dotnet.LatestRuntimeVersion;
             string nuGetConfig = await GenerateNuGetConfigIfNeededAsync(additionalFeed, packageVersion);
+
 
             TestRunner runner = new TestRunner(
                 cleaner: cleaner,

--- a/Turkey/TestRunner.cs
+++ b/Turkey/TestRunner.cs
@@ -21,12 +21,14 @@ namespace Turkey
         public Version RuntimeVersion { get; }
         public Version SdkVersion { get; }
         public List<string> CurrentPlatformIds { get; }
+        public IReadOnlyDictionary<string, string> EnvironmentVariables;
 
-        public SystemUnderTest(Version runtimeVersion, Version sdkVersion, List<string> platformIds)
+        public SystemUnderTest(Version runtimeVersion, Version sdkVersion, List<string> platformIds, IReadOnlyDictionary<string, string> environmentVariables)
         {
             RuntimeVersion = runtimeVersion;
             SdkVersion = sdkVersion;
             CurrentPlatformIds = platformIds;
+            EnvironmentVariables = environmentVariables;
         }
     }
 

--- a/Turkey/XUnitTest.cs
+++ b/Turkey/XUnitTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -47,12 +48,12 @@ namespace Turkey
 
         private async Task<PartialResult> BuildProjectAsync(CancellationToken token)
         {
-            return ProcessResultToPartialResult(await DotNet.BuildAsync(Directory, token));
+            return ProcessResultToPartialResult(await DotNet.BuildAsync(Directory, SystemUnderTest.EnvironmentVariables, token));
         }
 
         private async Task<PartialResult> TestProjectAsync(CancellationToken token)
         {
-            return ProcessResultToPartialResult(await DotNet.TestAsync(Directory, token));
+            return ProcessResultToPartialResult(await DotNet.TestAsync(Directory, SystemUnderTest.EnvironmentVariables, token));
         }
 
         private static PartialResult ProcessResultToPartialResult(DotNet.ProcessResult result)


### PR DESCRIPTION
Only enabled for OPENSSL_CONF for now.

See: https://github.com/redhat-developer/dotnet-bunny/issues/51