### PR TITLE
Switch back to portable application and .NET Core 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,12 @@ jobs:
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
         dotnet_version:
+          - "3.1"
+          - "5.0"
           - "6.0"
+        exclude:
+          - container_image: registry.fedoraproject.org/fedora:rawhide
+            dotnet_version: "5.0"
 
     container:
       image: ${{ matrix.container_image }}
@@ -54,7 +59,12 @@ jobs:
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
         dotnet_version:
+          - "3.1"
+          - "5.0"
           - "6.0"
+        exclude:
+          - container_image: registry.fedoraproject.org/fedora:rawhide
+            dotnet_version: "5.0"
 
     container:
       image: ${{ matrix.container_image }}
@@ -86,7 +96,9 @@ jobs:
       - name: Install Test dependencies
         timeout-minutes: 2
         run: |
-          dnf install -y python3 wget $(grep '^Dependencies: ' dotnet-regular-tests/README.md | cut -d: -f2-) --skip-broken
+          dnf install -y python3 wget \
+            $(grep '^Dependencies: ' dotnet-regular-tests/README.md | cut -d: -f2-) \
+            --skip-broken
 
       - name: Run reproducers
         run: |
@@ -99,7 +111,9 @@ jobs:
               rm -r dotnet-regular-tests/telemetry-is-off-by-default dotnet-regular-tests/bash-completion
           fi
 
-          ./bin/turkey dotnet-regular-tests -v
+          dotnet --info
+
+          dotnet turkey/Turkey.dll dotnet-regular-tests -v
 
       - name: Show Logs
         if: ${{ always() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y dotnet-sdk-6.0 git make
+          dnf install -y dotnet-sdk-3.1 git make
 
       - uses: actions/checkout@v2
 
@@ -35,7 +35,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: release-binaries
-          path: bin/turkey
+          path: turkey.tar.gz
 
   release:
     name: Create Release
@@ -71,16 +71,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: turkey
-          asset_name: turkey
-          asset_content_type: application/octet-stream
-
-      - name: Upload Release Asset (x86_64)
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: turkey
-          asset_name: turkey-x86_64
-          asset_content_type: application/octet-stream
+          asset_path: turkey.tar.gz
+          asset_name: turkey.tar.gz
+          asset_content_type: application/gzip

--- a/Turkey.Tests/Turkey.Tests.csproj
+++ b/Turkey.Tests/Turkey.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/Turkey/Turkey.csproj
+++ b/Turkey/Turkey.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UseAppHost>false</UseAppHost>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change breaks the release format. Now the release is a tarball
containing a single directory `turkey` containing `turkey/Turkey.dll`
which is the main dll of the application.

To support multiple .NET releases, platforms, architectures and even
operating system differences more easily, switch to portable builds with
roll-forward enabled. That allows the system .NET (which presuably works
on the combination of OS, architecture, system libraries, etc) to take
care of running the test suite itself.

That requires switching the application back to .NET Core 3.1 as the
TargetFramework. Enabling RollForward means the application should
continue to work fine on newer releases. This chnage enables running
unit tests to help confirm that.