### PR TITLE
Add nuget.org to any custom nuget config file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,16 @@ jobs:
         dotnet_version:
           - "3.1"
           - "6.0"
+        include:
+          - container_image: quay.io/centos/centos:stream9-development
+            dotnet_version: "7.0"
         exclude:
           - container_image: registry.fedoraproject.org/fedora:rawhide
             dotnet_version: "3.1"
           - container_image: registry.fedoraproject.org/fedora:37
+            dotnet_version: "3.1"
+          # alpine edge has openssl 1.1, not compatible with 3.1
+          - container_image: docker.io/library/alpine:edge
             dotnet_version: "3.1"
 
     container:
@@ -143,7 +149,7 @@ jobs:
 
           dotnet --info
 
-          dotnet turkey/Turkey.dll dotnet-regular-tests -v
+          dotnet turkey/Turkey.dll dotnet-regular-tests -v --timeout 600
 
       - name: Show Logs
         if: ${{ always() }}

--- a/Turkey/Program.cs
+++ b/Turkey/Program.cs
@@ -112,6 +112,11 @@ namespace Turkey
 
             Version packageVersion = dotnet.LatestRuntimeVersion;
             string nuGetConfig = await GenerateNuGetConfigIfNeededAsync(additionalFeed, packageVersion);
+            if (verbose && nuGetConfig != null)
+            {
+                Console.WriteLine("Using nuget.config: ");
+                Console.WriteLine(nuGetConfig);
+            }
 
             TestRunner runner = new TestRunner(
                 cleaner: cleaner,
@@ -174,6 +179,11 @@ namespace Turkey
 
                 if (urls.Any() || nugetConfig != null)
                 {
+                    // Add the default nuget repo that customer should always
+                    // be using anyway. This is the default, but still useful
+                    // if the nugetConfig has a <clear/> element that removes
+                    // it.
+                    urls.Add("https://api.nuget.org/v3/index.json");
                     return await nuget.GenerateNuGetConfig(urls, nugetConfig);
                 }
             }


### PR DESCRIPTION
It's the default; we expect customers to use it. But it's possible that the nuget.config file we use (eg, from source-build) has that removed so this force-adds it back.