### PR TITLE
Fix orphaned grandchild processes from tests causing test runner to hang.

### DIFF
--- a/Turkey.Tests/ProcessExtensionsTest.cs
+++ b/Turkey.Tests/ProcessExtensionsTest.cs
@@ -1,0 +1,55 @@
+using Xunit;
+using System.IO;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using System;
+
+namespace Turkey.Tests
+{
+    public class ProcessExtensiosnTests
+    {
+        [Fact]
+        public async Task WaitForExitAsync_DoesNotHangForOrphanedGrandChildren()
+        {
+            const int WaitTimeoutSeconds = 3;
+            const int GrandChildAgeSeconds = 3 * WaitTimeoutSeconds;
+
+            string filename = Path.GetTempFileName();
+            try
+            {
+                // This script creates a 'sleep' grandchild that outlives its parent.
+                File.WriteAllText(filename,
+                    $"""
+                    #!/bin/bash
+
+                    sleep {GrandChildAgeSeconds} &
+                    """);
+                File.SetUnixFileMode(filename, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+                var psi = new ProcessStartInfo()
+                {
+                    FileName = filename,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                };
+                using Process process = Process.Start(psi);
+
+                // Use a shorter timeout for WaitForExitAsync than the grandchild lives.
+                long startTime = Stopwatch.GetTimestamp();
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(WaitTimeoutSeconds));
+
+                // The WaitForExit completes by cancellation.
+                await Assert.ThrowsAsync<TaskCanceledException>(() => process.WaitForExitAsync(cts.Token, new StringWriter(), new StringWriter()));
+
+                // The completion takes at least the WaitTime.
+                TimeSpan elapsedTime = Stopwatch.GetElapsedTime(startTime);
+                Assert.True(elapsedTime >= TimeSpan.FromSeconds(WaitTimeoutSeconds), "The grandchild is not keeping the script alive");
+            }
+            finally
+            {
+                File.Delete(filename);
+            }
+        }
+    }
+}

--- a/Turkey.Tests/ProcessExtensionsTest.cs
+++ b/Turkey.Tests/ProcessExtensionsTest.cs
@@ -37,17 +37,10 @@ sleep {GrandChildAgeSeconds} &
                 using Process process = Process.Start(psi);
 
                 // Use a shorter timeout for WaitForExitAsync than the grandchild lives.
-                Stopwatch stopWatch = new Stopwatch();
-                stopWatch.Start();
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(WaitTimeoutSeconds));
 
                 // The WaitForExit completes by cancellation.
                 await Assert.ThrowsAsync<TaskCanceledException>(() => process.WaitForExitAsync(cts.Token, new StringWriter(), new StringWriter()));
-
-                // The completion takes at least the WaitTime.
-                stopWatch.Stop();
-                TimeSpan elapsedTime = stopWatch.Elapsed;
-                Assert.True(elapsedTime >= TimeSpan.FromSeconds(WaitTimeoutSeconds), "The grandchild is not keeping the script alive");
             }
             finally
             {

--- a/Turkey.Tests/Turkey.Tests.csproj
+++ b/Turkey.Tests/Turkey.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/Turkey.Tests/Turkey.Tests.csproj
+++ b/Turkey.Tests/Turkey.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RollForward>Major</RollForward>
   </PropertyGroup>

--- a/Turkey/ProcessExtensions.cs
+++ b/Turkey/ProcessExtensions.cs
@@ -8,7 +8,7 @@ namespace Turkey
 {
     public static class ProcessExtensions
     {
-        public static Task WaitForExitAsync(this Process process, CancellationToken token, TextWriter standardOutput, TextWriter standardError)
+        public static async Task WaitForExitAsync(this Process process, CancellationToken token, TextWriter standardOutput, TextWriter standardError)
         {
             process.EnableRaisingEvents = true;
             var outputHandler = new DataReceivedEventHandler(
@@ -32,53 +32,20 @@ namespace Turkey
             process.ErrorDataReceived += errorHandler;
             process.BeginErrorReadLine();
 
-            var tcs = new TaskCompletionSource<bool>();
-            int completionOwner = 0;
-            CancellationTokenRegistration ctr = default;
-            ctr = token.Register(() => CompleteTask(cancel: true));
-            process.Exited += delegate { CompleteTask(cancel: false); };
-            if (process.HasExited) // In case the Process exited before we've added the handler.
+            try
             {
-                CompleteTask(cancel: false);
+                await process.WaitForExitAsync(token);
             }
-            return tcs.Task;
-
-            void CompleteTask(bool cancel)
+            catch (OperationCanceledException ex)
             {
-                // Only one caller can complete the task.
-                if (Interlocked.CompareExchange(ref completionOwner, 1, 0) == 1)
+                try
                 {
-                    return;
+                    process.Kill(entireProcessTree: true);
                 }
+                catch
+                { }
 
-                if (cancel)
-                {
-                    try
-                    {
-                        process.Kill();
-                    }
-                    catch // Before .NET 3, Kill can throw if the process has terminated in the meanwhile.
-                    { }
-
-                }
-                else
-                {
-                    process.WaitForExit();  // Wait until we've received all output.
-                    ctr.Dispose();          // Don't root objects via the CancellationToken.
-                }
-
-                process.OutputDataReceived -= outputHandler;
-                process.ErrorDataReceived -= errorHandler;
-
-                // We're done using the process, now it's safe to complete the Task.
-                if (cancel)
-                {
-                    tcs.SetCanceled();
-                }
-                else
-                {
-                    tcs.SetResult(true);
-                }
+                throw;
             }
         }
     }


### PR DESCRIPTION
These orphaned grandchildren cause WaitForExit to block because they keep standard output and standard error open.

To fix this, we use the WaitForExitAsync method that was added in .NET 5. It enables reading the output until the CancellationToken is set.