### PR TITLE
Don't use the source-build nuget.config

### DIFF
--- a/Turkey/Program.cs
+++ b/Turkey/Program.cs
@@ -113,7 +113,8 @@ namespace Turkey
             );
 
             Version packageVersion = dotnet.LatestRuntimeVersion;
-            string nuGetConfig = await GenerateNuGetConfigIfNeededAsync(additionalFeed, packageVersion);
+            string nuGetConfig = await GenerateNuGetConfigIfNeededAsync(additionalFeed, packageVersion,
+                                                                        useSourceBuildNuGetConfig: false);
             if (verbose && nuGetConfig != null)
             {
                 Console.WriteLine("Using nuget.config: ");
@@ -133,7 +134,7 @@ namespace Turkey
             return exitCode;
         }
 
-        public static async Task<string> GenerateNuGetConfigIfNeededAsync(string additionalFeed, Version netCoreAppVersion)
+        public static async Task<string> GenerateNuGetConfigIfNeededAsync(string additionalFeed, Version netCoreAppVersion, bool useSourceBuildNuGetConfig)
         {
             var urls = new List<string>();
 
@@ -167,14 +168,17 @@ namespace Turkey
                 }
 
                 string nugetConfig = null;
-                try
+                if (useSourceBuildNuGetConfig)
                 {
-                    nugetConfig = await sourceBuild.GetNuGetConfigAsync(netCoreAppVersion);
-                }
-                catch( HttpRequestException exception )
-                {
-                    Console.WriteLine("WARNING: failed to get NuGet.config from source-build. Ignoring Exception:");
-                    Console.WriteLine(exception.ToString());
+                    try
+                    {
+                        nugetConfig = await sourceBuild.GetNuGetConfigAsync(netCoreAppVersion);
+                    }
+                    catch( HttpRequestException exception )
+                    {
+                        Console.WriteLine("WARNING: failed to get NuGet.config from source-build. Ignoring Exception:");
+                        Console.WriteLine(exception.ToString());
+                    }
                 }
 
                 if (urls.Any() || nugetConfig != null)


### PR DESCRIPTION
Using source-build's nuget.config adds lots of additional nuget sources. The nuget client tries to connect to all of them at once to minimize total time (due to network latency). It does this by spawning lots of network connections. Each network connection consumes file descriptors. This works fine on x64, but fails for .NET runtimes that use Mono, because mono has a hard 1024 limit for file descriptors. See https://github.com/dotnet/runtime/issues/82428 for details.

Additionally, since the goal of the tests tests is to mirror the results that end-users using the .NET SDK will see, adding additional nuget sources by default seems a bit weird.

However, the additional nuget sources were added for a reason. They might be needed for non-public and/or in-development releases. If so, we can selectively re-enable the additional nuget.config sources nuget.config with some command line flags.