### PR TITLE
Fix identifying Mono vs CoreCLR runtimes

### DIFF
--- a/Turkey/DotNet.cs
+++ b/Turkey/DotNet.cs
@@ -61,8 +61,11 @@ namespace Turkey
             }
         }
 
+        public bool IsCoreClrRuntime(Version runtimeVersion)
+            => IsCoreClrRuntime(DotnetRoot, runtimeVersion);
+
         public bool IsMonoRuntime(Version runtimeVersion)
-            => IsMonoRuntime(DotnetRoot, runtimeVersion);
+            => !IsCoreClrRuntime(runtimeVersion);
 
         public List<Version> SdkVersions
         {
@@ -137,7 +140,7 @@ namespace Turkey
             return await ProcessRunner.RunAsync(startInfo, logger, token);
         }
 
-        private static bool IsMonoRuntime(string dotnetRoot, Version version)
+        private static bool IsCoreClrRuntime(string dotnetRoot, Version version)
         {
             string[] runtimeDirectories = Directory.GetDirectories(Path.Combine(dotnetRoot, "shared", "Microsoft.NETCore.App"))
                                             .Where(dir => Version.Parse(Path.GetFileName(dir)) == version)
@@ -153,7 +156,7 @@ namespace Turkey
             }
 
             string runtimeDir = runtimeDirectories[0];
-            return File.Exists(Path.Combine(runtimeDir, "mono-gc.h"));
+            return File.Exists(Path.Combine(runtimeDir, "libcoreclrtraceptprovider.so"));
         }
 
         private static string? FindProgramInPath(string program)


### PR DESCRIPTION
We currently use `mono-gc.h` as signal that the runtime is a mono-based runtime. Unfortuatnely, that file is only included with 7.0. This makes us mis-identify Mono-based 6.0 runtimes as CoreCLR-based instead.

Instead, use libcoreclrtraceptprovider.so which is available CoreCLR-based platforms (eg, x86_64) but not Mono-based ones. This file exists on 6.0 and later:

    $ find /usr/lib64/dotnet -iname libcoreclrtraceptprovider.so
    /usr/lib64/dotnet/shared/Microsoft.NETCore.App/8.0.0-preview.5.23280.8/libcoreclrtraceptprovider.so
    /usr/lib64/dotnet/shared/Microsoft.NETCore.App/7.0.7/libcoreclrtraceptprovider.so
    /usr/lib64/dotnet/shared/Microsoft.NETCore.App/6.0.18/libcoreclrtraceptprovider.so