### PR TITLE
UX update for list of failed tests

### DIFF
--- a/Turkey/TestOutputFormat.cs
+++ b/Turkey/TestOutputFormat.cs
@@ -67,7 +67,7 @@ namespace Turkey
                 Console.WriteLine("The following tests failed: ");
                 foreach(var test in failedTests)
                 {
-                   Console.WriteLine($"{string.Format("{0,-30}", test.Name)}({test.Duration})");
+                    Console.WriteLine($"{string.Format("{0,-30}", test.Name)}({test.Duration})");
                 }
             }
 

--- a/Turkey/TestRunner.cs
+++ b/Turkey/TestRunner.cs
@@ -152,7 +152,10 @@ namespace Turkey
                 await outputs.ForEachAsync(output => output.AfterRunningTestAsync(testName, testResult, testLog, testTimeWatch.Elapsed));
                 }
             
-            await outputs.ForEachAsync(outputs => outputs.PrintFailedTests());
+            if (results.Failed != 0 )
+            {
+                await outputs.ForEachAsync(outputs => outputs.PrintFailedTests());
+            }
 
             await outputs.ForEachAsync(output => output.AfterRunningAllTestsAsync(results));
 


### PR DESCRIPTION
The line ```The following tests failed:``` was appearing when there were no test failures. This update simply changes it to only display when there are failed tests.