### PR TITLE
Update ci matrix and .NET installation instructions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,29 +15,16 @@ jobs:
       matrix:
         container_image:
           - quay.io/centos/centos:stream9
-          - quay.io/centos/centos:stream10-development
-          - registry.fedoraproject.org/fedora:39
+          - quay.io/centos/centos:stream10
           - registry.fedoraproject.org/fedora:40
+          - registry.fedoraproject.org/fedora:41
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
           - registry.access.redhat.com/ubi9
         dotnet_version:
-          - "6.0"
           - "8.0"
-        exclude:
-          - container_image: registry.fedoraproject.org/fedora:rawhide
-            dotnet_version: "6.0"
-          - container_image: quay.io/centos/centos:stream10-development
-            dotnet_version: "6.0"
-        include:
-          - container_image: registry.fedoraproject.org/fedora:40
-            dotnet_version: "9.0"
-          - container_image: registry.fedoraproject.org/fedora:rawhide
-            dotnet_version: "9.0"
-          - container_image: quay.io/centos/centos:stream10-development
-            dotnet_version: "9.0"
+          - "9.0"
           
-
     container:
       image: ${{ matrix.container_image }}
       options: --security-opt seccomp=unconfined
@@ -47,22 +34,13 @@ jobs:
         timeout-minutes: 5
         run: |
           set -euo pipefail
-          if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
-            dnf install 'dnf-command(copr)' -y
-            cat /etc/os-release
-            if grep centos /etc/os-release ; then
-              dnf copr enable @dotnet-sig/dotnet-preview centos-stream-10-x86_64 -y
-            else
-              dnf copr enable @dotnet-sig/dotnet-preview -y
-            fi
-            dnf install -y dotnet-sdk-aot-${{ matrix.dotnet_version }}
-          fi
           dnf install -y dotnet-sdk-${{ matrix.dotnet_version }} git make
-          if [[ ! ${{ matrix.dotnet_version }} == *6* ]]; then
-            dnf install -y \
-              dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
-              dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
-              aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
+          dnf install -y \
+            dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
+            dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
+            aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
+          if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
+            dnf install -y dotnet-sdk-aot-${{ matrix.dotnet_version }}
           fi
 
       - uses: actions/checkout@v2
@@ -99,28 +77,15 @@ jobs:
       matrix:
         container_image:
           - quay.io/centos/centos:stream9
-          - quay.io/centos/centos:stream10-development
-          - registry.fedoraproject.org/fedora:39
+          - quay.io/centos/centos:stream10
           - registry.fedoraproject.org/fedora:40
+          - registry.fedoraproject.org/fedora:41
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
           - registry.access.redhat.com/ubi9
         dotnet_version:
-          - "6.0"
           - "8.0"
-        exclude:
-          - container_image: registry.fedoraproject.org/fedora:rawhide
-            dotnet_version: "6.0"
-          - container_image: quay.io/centos/centos:stream10-development
-            dotnet_version: "6.0"
-        include:
-          - container_image: registry.fedoraproject.org/fedora:40
-            dotnet_version: "9.0"
-          - container_image: registry.fedoraproject.org/fedora:rawhide
-            dotnet_version: "9.0"
-          - container_image: quay.io/centos/centos:stream10-development
-            dotnet_version: "9.0"
-
+          - "9.0"
 
     container:
       image: ${{ matrix.container_image }}
@@ -131,22 +96,13 @@ jobs:
         timeout-minutes: 5
         run: |
           set -euo pipefail
-          if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
-            dnf install 'dnf-command(copr)' -y
-            cat /etc/os-release
-            if grep centos /etc/os-release ; then
-              dnf copr enable @dotnet-sig/dotnet-preview centos-stream-10-x86_64 -y
-            else
-              dnf copr enable @dotnet-sig/dotnet-preview -y
-            fi
-            dnf install -y dotnet-sdk-aot-${{ matrix.dotnet_version }}
-          fi
           dnf install -y dotnet-sdk-${{ matrix.dotnet_version }} git make
-          if [[ ! ${{ matrix.dotnet_version }} == *6* ]]; then
-            dnf install -y \
-              dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
-              dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
-              aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
+          dnf install -y \
+            dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
+            dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
+            aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
+          if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
+            dnf install -y dotnet-sdk-aot-${{ matrix.dotnet_version }}
           fi
 
       # We need to fetch the tags, so 'git tag' in 'make publish' below works


### PR DESCRIPTION
Adding Fedora41 to the CI matrix while also removing Fedora39. .NET 6 has also been removed.
The installation steps for .NET 9 have been updated now that it has been publically released.