### PR TITLE
Remove warnings from terminal when compiling the test runner.

### DIFF
--- a/Turkey/BashTest.cs
+++ b/Turkey/BashTest.cs
@@ -38,7 +38,7 @@ namespace Turkey
                 startInfo.EnvironmentVariables.Add(key, value);
             }
 
-            int exitCode = await ProcessRunner.RunAsync(startInfo, logger, cancellationToken);
+            int exitCode = await ProcessRunner.RunAsync(startInfo, logger, cancellationToken).ConfigureAwait(false);
 
             return exitCode == 0 ? TestResult.Passed : TestResult.Failed;
         }

--- a/Turkey/Cleaner.cs
+++ b/Turkey/Cleaner.cs
@@ -36,7 +36,9 @@ namespace Turkey
             yield return "project.lock.json";
         }
 
-        public async Task CleanProjectLocalDotNetCruftAsync()
+#pragma warning disable CA1822 // Mark members as static
+        public Task CleanProjectLocalDotNetCruftAsync()
+#pragma warning restore CA1822 // Mark members as static
         {
 
             foreach(var name in LocalProjectCruft())
@@ -51,9 +53,12 @@ namespace Turkey
                     File.Delete(name);
                 }
             }
+            return Task.CompletedTask;
         }
 
-        public async Task CleanLocalDotNetCacheAsync()
+#pragma warning disable CA1822 // Mark members as static
+        public Task CleanLocalDotNetCacheAsync()
+#pragma warning restore CA1822 // Mark members as static
         {
             foreach (var path in CruftDirectoryGlobs())
             {
@@ -77,12 +82,14 @@ namespace Turkey
                     Console.WriteLine($"WARNING: unable to expand {path}");
                 }
             }
-            return;
+            return Task.CompletedTask;
         }
 
+#pragma warning disable CA1822 // Mark members as static
         public IEnumerable<string> ExpandPath(string pathWithGlob)
+#pragma warning restore CA1822 // Mark members as static
         {
-            if (pathWithGlob.StartsWith("~"))
+            if (pathWithGlob.StartsWith("~", StringComparison.Ordinal))
             {
                 pathWithGlob = Environment.GetEnvironmentVariable("HOME") + pathWithGlob.Substring(1);
             }

--- a/Turkey/DotNet.cs
+++ b/Turkey/DotNet.cs
@@ -43,7 +43,7 @@ namespace Turkey
                     string output = p.StandardOutput.ReadToEnd();
                     var list = output
                         .Split("\n", StringSplitOptions.RemoveEmptyEntries)
-                        .Where(line => line.StartsWith("Microsoft.NETCore.App"))
+                        .Where(line => line.StartsWith("Microsoft.NETCore.App", StringComparison.Ordinal))
                         .Select(line => line.Split(" ")[1])
                         .Select(versionString => Version.Parse(versionString))
                         .OrderBy(x => x)
@@ -137,7 +137,7 @@ namespace Turkey
                 startInfo.EnvironmentVariables.Add(key, value);
             }
 
-            return await ProcessRunner.RunAsync(startInfo, logger, token);
+            return await ProcessRunner.RunAsync(startInfo, logger, token).ConfigureAwait(false);
         }
 
         private static bool IsCoreClrRuntime(string dotnetRoot, Version version)
@@ -159,7 +159,9 @@ namespace Turkey
             return File.Exists(Path.Combine(runtimeDir, "libcoreclrtraceptprovider.so"));
         }
 
+        #nullable enable
         private static string? FindProgramInPath(string program)
+        #nullable disable
         {
             string[] paths = Environment.GetEnvironmentVariable("PATH")?.Split(':', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>();
             foreach (string p in paths)

--- a/Turkey/IEnumerableExtensions.cs
+++ b/Turkey/IEnumerableExtensions.cs
@@ -10,7 +10,7 @@ namespace Turkey
         {
             foreach (T item in items)
             {
-                await task(item);
+                await task(item).ConfigureAwait(false);
             }
         }
     }

--- a/Turkey/NuGet.cs
+++ b/Turkey/NuGet.cs
@@ -21,27 +21,34 @@ namespace Turkey
         public async Task<bool> IsPackageLiveAsync(string name, Version version)
         {
             var url = $"https://api-v2v3search-0.nuget.org/autocomplete?id={name}&prerelease=true";
-            var result = await _client.GetStringAsync(url);
-            return await IsPackageLiveAsync(name, version, result);
+            Uri uri = new(url);
+            var result = await _client.GetStringAsync(uri).ConfigureAwait(false);
+            return await IsPackageLiveAsync(name, version, result).ConfigureAwait(false);
         }
 
-        public async Task<bool> IsPackageLiveAsync(string name, Version version, string json)
+#pragma warning disable CA1801 // Remove unused parameter
+#pragma warning disable CA1822 // Mark members as static
+        public Task<bool> IsPackageLiveAsync(string name, Version version, string json)
+#pragma warning restore CA1822 // Mark members as static
+#pragma warning restore CA1801 // Remove unused parameter
         {
             JObject deserialized = (JObject) JsonConvert.DeserializeObject(json);
-            JArray versions = (JArray) deserialized.GetValue("data");
+            JArray versions = (JArray) deserialized.GetValue("data", StringComparison.Ordinal);
             var found = versions.Children<JToken>()
-                .Where(v => v.Value<string>().Equals(version.ToString()))
+                .Where(v => v.Value<string>().Equals(version.ToString(), StringComparison.Ordinal))
                 .Any();
-            return found;
+            return Task.FromResult(found);
         }
 
-        public async Task<string> GenerateNuGetConfig(List<string> urls, string nugetConfig = null)
+#pragma warning disable CA1822 // Mark members as static
+        public Task<string> GenerateNuGetConfig(List<string> urls, string nugetConfig = null)
+#pragma warning restore CA1822 // Mark members as static
         {
-            if( !urls.Any() && nugetConfig == null )
-                throw new ArgumentNullException();
+            if (!urls.Any())
+                ArgumentNullException.ThrowIfNull(nugetConfig);
 
             string sources = null;
-            if( urls.Any() )
+            if (urls.Any())
             {
                 var sourceParts = new List<string>(urls.Count);
                 for( int i = 0; i < urls.Count; i++ )
@@ -54,6 +61,7 @@ namespace Turkey
                 {
                     sources = $"    {sources}\n";
                 }
+            
             }
 
             if( string.IsNullOrWhiteSpace(nugetConfig) )
@@ -66,9 +74,9 @@ namespace Turkey
             }
 
             if( !string.IsNullOrWhiteSpace(sources) )
-                nugetConfig = nugetConfig.Replace("</packageSources>", sources + "</packageSources>");
+                nugetConfig = nugetConfig.Replace("</packageSources>", sources + "</packageSources>", StringComparison.Ordinal);
 
-            return nugetConfig;
+            return Task.FromResult(nugetConfig);
         }
 
     }

--- a/Turkey/PlatformId.cs
+++ b/Turkey/PlatformId.cs
@@ -18,7 +18,9 @@ namespace Turkey
 
         public List<string> ComputePlatformIds(string[] osReleaseLines, string lddVersionOutput)
         {
-            string arch = Enum.GetName(typeof(Architecture), RuntimeInformation.OSArchitecture).ToLowerInvariant();
+            #pragma warning disable CA1308 // Normalize strings to uppercase
+            string arch = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
+            #pragma warning restore CA1308 // Normalize strings to uppercase
             return ComputePlatformIds(osReleaseLines, arch, lddVersionOutput);
         }
 
@@ -63,17 +65,17 @@ namespace Turkey
             return platforms.ToList();
         }
 
-        private string GetValue(string key, string[] lines)
+        private static string GetValue(string key, string[] lines)
         {
             return lines.Where(line => line.StartsWith(key + "=", StringComparison.Ordinal)).Last().Substring((key + "=").Length);
         }
 
-        private string Unquote(string text)
+        private static string Unquote(string text)
         {
             // TODO implement proper un-escaping
             // This is a limited shell-style syntax described at
             // https://www.freedesktop.org/software/systemd/man/os-release.html
-            if (text.StartsWith("\"") && text.EndsWith("\""))
+            if (text.StartsWith("\"", StringComparison.Ordinal) && text.EndsWith("\"", StringComparison.Ordinal))
             {
                 return text.Substring(1, text.Length - 2);
             }
@@ -81,7 +83,9 @@ namespace Turkey
             return text;
         }
 
+#pragma warning disable CA1822 // Mark members as static
         internal string GetLddVersion()
+#pragma warning restore CA1822 // Mark members as static
         {
             using (Process p = new Process())
             {

--- a/Turkey/ProcessExtensions.cs
+++ b/Turkey/ProcessExtensions.cs
@@ -12,7 +12,7 @@ namespace Turkey
         {
             logger($"Executing {psi.FileName} with arguments {psi.Arguments} in working directory {psi.WorkingDirectory}");
             using var process = Process.Start(psi);
-            await process.WaitForExitAsync(logger, token);
+            await process.WaitForExitAsync(logger, token).ConfigureAwait(false);
             return process.ExitCode;
         }
     }
@@ -43,11 +43,11 @@ namespace Turkey
 
             try
             {
-                await process.WaitForExitAsync(token);
+                await process.WaitForExitAsync(token).ConfigureAwait(false);
 
                 logger($"Process Exit Code: {process.ExitCode}");
             }
-            catch (OperationCanceledException ex)
+            catch (OperationCanceledException)
             {
                 lock (logger)
                 {

--- a/Turkey/Program.cs
+++ b/Turkey/Program.cs
@@ -12,7 +12,9 @@ using System.Runtime.InteropServices;
 
 namespace Turkey
 {
+#pragma warning disable CA1052 // Static holder types should be Static or NotInheritable
     public class Program
+#pragma warning restore CA1052 // Static holder types should be Static or NotInheritable
     {
         public static readonly Option<bool> verboseOption = new Option<bool>(
             new string[] { "--verbose", "-v" },
@@ -118,7 +120,7 @@ namespace Turkey
 
             Version packageVersion = runtimeVersion;
             string nuGetConfig = await GenerateNuGetConfigIfNeededAsync(additionalFeed, packageVersion,
-                                                                        useSourceBuildNuGetConfig: false);
+                                                                        useSourceBuildNuGetConfig: false).ConfigureAwait(false);
             if (verbose && nuGetConfig != null)
             {
                 Console.WriteLine("Using nuget.config: ");
@@ -132,7 +134,7 @@ namespace Turkey
                 verboseOutput: verbose,
                 nuGetConfig: nuGetConfig);
 
-            var results = await runner.ScanAndRunAsync(testOutputs, logDir.FullName, defaultTimeout);
+            var results = await runner.ScanAndRunAsync(testOutputs, logDir.FullName, defaultTimeout).ConfigureAwait(false);
 
             int exitCode = (results.Failed == 0) ? 0 : 1;
             return exitCode;
@@ -157,7 +159,7 @@ namespace Turkey
                 {
                     try
                     {
-                        nugetConfig = await sourceBuild.GetNuGetConfigAsync(netCoreAppVersion);
+                        nugetConfig = await sourceBuild.GetNuGetConfigAsync(netCoreAppVersion).ConfigureAwait(false);
                     }
                     catch( HttpRequestException exception )
                     {
@@ -173,14 +175,16 @@ namespace Turkey
                     // if the nugetConfig has a <clear/> element that removes
                     // it.
                     urls.Add("https://api.nuget.org/v3/index.json");
-                    return await nuget.GenerateNuGetConfig(urls, nugetConfig);
+                    return await nuget.GenerateNuGetConfig(urls, nugetConfig).ConfigureAwait(false);
                 }
             }
 
             return null;
         }
 
+#pragma warning disable CA1801 // Remove unused parameter
         public static IReadOnlySet<string> CreateTraits(Version runtimeVersion, Version sdkVersion, List<string> rids, bool isMonoRuntime, IEnumerable<string> additionalTraits)
+#pragma warning restore CA1801 // Remove unused parameter
         {
             var traits = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -199,7 +203,9 @@ namespace Turkey
             }
 
             // Add 'arch=' trait.
+#pragma warning disable CA1308 // Normalize strings to uppercase
             string arch = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
+#pragma warning restore CA1308 // Normalize strings to uppercase
             traits.Add($"arch={arch}");
 
             // Add 'runtime=' trait.
@@ -231,7 +237,7 @@ namespace Turkey
             rootCommand.AddOption(traitOption);
             rootCommand.AddOption(timeoutOption);
 
-            return await rootCommand.InvokeAsync(args);
+            return await rootCommand.InvokeAsync(args).ConfigureAwait(false);
         }
     }
 }

--- a/Turkey/SourceBuild.cs
+++ b/Turkey/SourceBuild.cs
@@ -16,11 +16,12 @@ namespace Turkey
             this._client = client;
         }
 
-        public string GetBranchContentUrl(Version version)
+        public static System.Uri GetBranchContentUrl(Version version)
         {
             var branchName = "release/" + version.MajorMinor + ".1xx";
             var url = $"https://raw.githubusercontent.com/dotnet/installer/{branchName}/";
-            return url;
+            Uri uri = new(url);
+            return uri;
         }
 
         public async Task<string> GetProdConFeedAsync(Version version)
@@ -31,9 +32,10 @@ namespace Turkey
             }
 
             var url = GetBranchContentUrl(version) + "ProdConFeed.txt";
-            var feedUrl = await _client.GetStringAsync(url);
-
-            using(var response = await _client.GetAsync(feedUrl))
+            Uri uri = new(url);
+            var feedUrl = await _client.GetStringAsync(uri).ConfigureAwait(false);
+            Uri feedUri = new(feedUrl);
+            using(var response = await _client.GetAsync(feedUri).ConfigureAwait(false))
             {
                 if (!response.IsSuccessStatusCode)
                 {
@@ -46,11 +48,12 @@ namespace Turkey
         public async Task<string> GetNuGetConfigAsync(Version version)
         {
             string url = GetBranchContentUrl(version) + "NuGet.config";
+            Uri uri = new(url);
 
             string nugetConfig = null;
             try
             {
-                nugetConfig = await _client.GetStringAsync(url);
+                nugetConfig = await _client.GetStringAsync(uri).ConfigureAwait(false);
             }
             catch( HttpRequestException e )
             {

--- a/Turkey/Test.cs
+++ b/Turkey/Test.cs
@@ -18,8 +18,12 @@ namespace Turkey
         public string Type { get; set; }
         public bool Cleanup { get; set; }
         public double TimeoutMultiplier { get; set; } = 1.0;
+
+        #pragma warning disable CA2227 // Change to be read-only by removing the property setter.
         public List<string> IgnoredRIDs { get; set; } = new();
         public List<string> SkipWhen { get; set; } = new();
+
+        #pragma warning restore CA2227
     }
 
     // TODO is this a strongly-typed enum in C#?
@@ -58,10 +62,10 @@ namespace Turkey
                 {
                     Console.WriteLine($"WARNING: overwriting {path}");
                 }
-                await File.WriteAllTextAsync(path, NuGetConfig);
+                await File.WriteAllTextAsync(path, NuGetConfig).ConfigureAwait(false);
             }
 
-            var testResult = await InternalRunAsync(logger, cancelltionToken);
+            var testResult = await InternalRunAsync(logger, cancelltionToken).ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(NuGetConfig))
             {

--- a/Turkey/TestParser.cs
+++ b/Turkey/TestParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata.Ecma335;
 using System.Threading.Tasks;
 
 using Newtonsoft.Json;
@@ -15,7 +16,9 @@ namespace Turkey
             return TryParseAsync(system, nuGetConfig, dir, File.ReadAllText(testConfiguration.FullName));
         }
 
-        public async Task<(bool Success, Test Test)> TryParseAsync(SystemUnderTest system, string nuGetConfig, DirectoryInfo directory, string testConfiguration)
+#pragma warning disable CA1801 // Remove unused parameter
+        public Task<(bool Success, Test Test)> TryParseAsync(SystemUnderTest system, string nuGetConfig, DirectoryInfo directory, string testConfiguration)
+#pragma warning restore CA1801 // Remove unused parameter
         {
             // TODO: async
             var fileName = Path.Combine(directory.FullName, "test.json");
@@ -32,12 +35,12 @@ namespace Turkey
             {
                 case "xunit":
                     test = new XUnitTest(directory, system, nuGetConfig, descriptor, enabled);
-                    return (true, test);
+                    return Task.FromResult((true, test));
                 case "bash":
                     test = new BashTest(directory, system, nuGetConfig, descriptor, enabled);
-                    return (true, test);
+                    return Task.FromResult((true, test));
                 default:
-                    return (false, null);
+                    return Task.FromResult((false, (Test)null));
             }
         }
 
@@ -98,7 +101,9 @@ namespace Turkey
         }
 
 
+#pragma warning disable CA1822 // Mark members as static
         private bool VersionMatches(TestDescriptor test, Version runtimeVersion)
+#pragma warning restore CA1822 // Mark members as static
         {
             if (test.VersionSpecific)
             {

--- a/Turkey/Version.cs
+++ b/Turkey/Version.cs
@@ -134,7 +134,9 @@ namespace Turkey
 
         public override int GetHashCode()
         {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
             throw new NotImplementedException();
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
         }
 
     }

--- a/Turkey/XUnitTest.cs
+++ b/Turkey/XUnitTest.cs
@@ -16,8 +16,8 @@ namespace Turkey
 
         protected override async Task<TestResult> InternalRunAsync(Action<string> logger, CancellationToken cancellationToken)
         {
-            bool success =    await BuildProjectAsync(logger, cancellationToken) == 0
-                           && await RunTestProjectAsync(logger, cancellationToken) == 0;
+            bool success =    await BuildProjectAsync(logger, cancellationToken).ConfigureAwait(false) == 0
+                           && await RunTestProjectAsync(logger, cancellationToken).ConfigureAwait(false) == 0;
 
             return success ? TestResult.Passed : TestResult.Failed;
         }


### PR DESCRIPTION
A fix for the test runner that patches most of the warnings that are reported in the terminal when compiling the test runner. Some warnings were suppressed as it was too time-consuming or there were impacts to other parts of the test runner when they were fixed.

Fixes #83 