### PR TITLE
Add new release status trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,22 @@ jobs:
         container_image:
           - quay.io/centos/centos:stream9
           - quay.io/centos/centos:stream10
-          - registry.fedoraproject.org/fedora:40
           - registry.fedoraproject.org/fedora:41
+          - registry.fedoraproject.org/fedora:42
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
           - registry.access.redhat.com/ubi9
+          - registry.access.redhat.com/ubi10
         dotnet_version:
           - "8.0"
           - "9.0"
+        include:
+          - container_image: registry.fedoraproject.org/fedora:42
+            dotnet_version: "10.0"
+          - container_image: registry.fedoraproject.org/fedora:rawhide
+            dotnet_version: "10.0"
+          - container_image: quay.io/centos/centos:stream10
+            dotnet_version: "10.0"
           
     container:
       image: ${{ matrix.container_image }}
@@ -34,12 +42,20 @@ jobs:
         timeout-minutes: 5
         run: |
           set -euo pipefail
+          if [[ ${{ matrix.dotnet_version }} == 10.* ]]; then
+            dnf install 'dnf-command(copr)' -y
+            if grep centos /etc/os-release; then
+              dnf copr enable @dotnet-sig/dotnet-preview centos-stream-10-x86_64 -y
+            else
+              dnf copr enable @dotnet-sig/dotnet-preview -y
+            fi
+          fi
           dnf install -y dotnet-sdk-${{ matrix.dotnet_version }} git make
           dnf install -y \
             dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
             dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
             aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
-          if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
+          if [[ ${{ matrix.dotnet_version }} != 8.* ]]; then
             dnf install -y dotnet-sdk-aot-${{ matrix.dotnet_version }}
           fi
 
@@ -78,14 +94,22 @@ jobs:
         container_image:
           - quay.io/centos/centos:stream9
           - quay.io/centos/centos:stream10
-          - registry.fedoraproject.org/fedora:40
           - registry.fedoraproject.org/fedora:41
+          - registry.fedoraproject.org/fedora:42
           - registry.fedoraproject.org/fedora:rawhide
           - registry.access.redhat.com/ubi8
           - registry.access.redhat.com/ubi9
+          - registry.access.redhat.com/ubi10
         dotnet_version:
           - "8.0"
           - "9.0"
+        include:
+          - container_image: registry.fedoraproject.org/fedora:42
+            dotnet_version: "10.0"
+          - container_image: registry.fedoraproject.org/fedora:rawhide
+            dotnet_version: "10.0"
+          - container_image: quay.io/centos/centos:stream10
+            dotnet_version: "10.0"
 
     container:
       image: ${{ matrix.container_image }}
@@ -96,12 +120,20 @@ jobs:
         timeout-minutes: 5
         run: |
           set -euo pipefail
+          if [[ ${{ matrix.dotnet_version }} == 10.* ]]; then
+            dnf install 'dnf-command(copr)' -y
+            if grep centos /etc/os-release; then
+              dnf copr enable @dotnet-sig/dotnet-preview centos-stream-10-x86_64 -y
+            else
+              dnf copr enable @dotnet-sig/dotnet-preview -y
+            fi
+          fi
           dnf install -y dotnet-sdk-${{ matrix.dotnet_version }} git make
           dnf install -y \
             dotnet-sdk-dbg-${{ matrix.dotnet_version }} \
             dotnet-runtime-dbg-${{ matrix.dotnet_version }} \
             aspnetcore-runtime-dbg-${{ matrix.dotnet_version }}
-          if [[ ${{ matrix.dotnet_version }} == 9.* ]]; then
+          if [[ ${{ matrix.dotnet_version }} != 8.* ]]; then
             dnf install -y dotnet-sdk-aot-${{ matrix.dotnet_version }}
           fi
 

--- a/Turkey.Tests/ProgramTest.cs
+++ b/Turkey.Tests/ProgramTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Linq;
 using Xunit;
+using Microsoft.VisualBasic;
 
 namespace Turkey.Tests
 {
@@ -51,22 +52,24 @@ namespace Turkey.Tests
             Version runtimeVersion = Version.Parse("6.5");
             Version sdkVersion = Version.Parse("3.1");
 
-            string[] expectedVersionTraits = new[] { "version=6.5", "version=6" };
+            var release = "released";
+
+            string[] expectedVersionTraits = new[] { "version=6.5", "version=6", "status=released" };
             string expectedArch = $"arch={OSArchitectureName}";
 
             // default traits.
-            yield return new object[] { runtimeVersion, sdkVersion, Array.Empty<string>(), false, Array.Empty<string>(), CombineTraits() };
+            yield return new object[] { runtimeVersion, sdkVersion, release, Array.Empty<string>(), false, Array.Empty<string>(), CombineTraits() };
 
             // 'runtime=mono'
-            yield return new object[] { runtimeVersion, sdkVersion, Array.Empty<string>(), true, Array.Empty<string>(), CombineTraits(isMonoRuntime: true) };
+            yield return new object[] { runtimeVersion, sdkVersion, release, Array.Empty<string>(), true, Array.Empty<string>(), CombineTraits(isMonoRuntime: true) };
 
             // 'os=..' and 'rid=...' are added for the platform rids.
-            yield return new object[] { runtimeVersion, sdkVersion, new[] { "linux-x64", "fedora.37-x64", "linux-musl-x64" }, false, Array.Empty<string>(),
+            yield return new object[] { runtimeVersion, sdkVersion, release, new[] { "linux-x64", "fedora.37-x64", "linux-musl-x64" }, false, Array.Empty<string>(),
                                     CombineTraits(new[] { "os=linux", "os=fedora.37", "os=linux-musl",
                                                           "rid=linux-x64", "rid=fedora.37-x64", "rid=linux-musl-x64" } ) };
 
             // additional traits are added.
-            yield return new object[] { runtimeVersion, sdkVersion, Array.Empty<string>(), false, new[] { "blue", "green" },
+            yield return new object[] { runtimeVersion, sdkVersion, release, Array.Empty<string>(), false, new[] { "blue", "green" },
                                             CombineTraits(new[] { "blue", "green" } ) };
 
             string[] CombineTraits(string[] expectedAdditionalTraits = null, bool isMonoRuntime = false)
@@ -79,9 +82,9 @@ namespace Turkey.Tests
 
         [Theory]
         [MemberData(nameof(SystemTraits_MemberData))]
-        public void SystemTraits(Version runtimeVersion, Version sdkVersion, string[] rids, bool isMonoRuntime, string[] additionalTraits, string[] expectedTraits)
+        public void SystemTraits(Version runtimeVersion, Version sdkVersion, string release, string[] rids, bool isMonoRuntime, string[] additionalTraits, string[] expectedTraits)
         {
-            IReadOnlySet<string> systemTraits = Program.CreateTraits(runtimeVersion, sdkVersion, new List<string>(rids), isMonoRuntime, additionalTraits);
+            IReadOnlySet<string> systemTraits = Program.CreateTraits(runtimeVersion, sdkVersion, new List<string>(rids), isMonoRuntime, release, additionalTraits);
 
             Assert.Equal(expectedTraits.OrderBy(s => s), systemTraits.OrderBy(s => s));
         }

--- a/Turkey.Tests/VersionTest.cs
+++ b/Turkey.Tests/VersionTest.cs
@@ -102,7 +102,7 @@ namespace Turkey.Tests
         public void TestToString()
         {
             var v1 = Version.Parse("1.0");
-            Assert.Equal("1.0", v1.ToString());
+            Assert.Equal("1.0.0", v1.ToString());
         }
     }
 }

--- a/Turkey/Program.cs
+++ b/Turkey/Program.cs
@@ -104,7 +104,7 @@ namespace Turkey
             var sanitizer = new EnvironmentVariableSanitizer();
             var envVars = sanitizer.SanitizeCurrentEnvironmentVariables();
 
-            var traits = CreateTraits(runtimeVersion, dotnet.LatestSdkVersion, platformIds, dotnet.IsMonoRuntime(runtimeVersion), trait);
+            var traits = CreateTraits(runtimeVersion, dotnet.LatestSdkVersion, platformIds, dotnet.IsMonoRuntime(runtimeVersion), runtimeVersion.Release, trait);
             Console.WriteLine($"Tests matching these traits will be skipped: {string.Join(", ", traits.OrderBy(s => s))}.");
 
             envVars["TestTargetFramework"] = $"net{runtimeVersion.Major}.{runtimeVersion.Minor}";
@@ -183,7 +183,7 @@ namespace Turkey
         }
 
 #pragma warning disable CA1801 // Remove unused parameter
-        public static IReadOnlySet<string> CreateTraits(Version runtimeVersion, Version sdkVersion, List<string> rids, bool isMonoRuntime, IEnumerable<string> additionalTraits)
+        public static IReadOnlySet<string> CreateTraits(Version runtimeVersion, Version sdkVersion, List<string> rids, bool isMonoRuntime, string release, IEnumerable<string> additionalTraits)
 #pragma warning restore CA1801 // Remove unused parameter
         {
             var traits = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -191,6 +191,9 @@ namespace Turkey
             // Add 'version=' traits.
             traits.Add($"version={runtimeVersion.Major}.{runtimeVersion.Minor}");
             traits.Add($"version={runtimeVersion.Major}");
+
+            // Add 'status=' trait.
+            traits.Add($"status={runtimeVersion.Release}");
 
             // Add 'os=', 'rid=' traits.
             foreach (var rid in rids)

--- a/Turkey/Version.cs
+++ b/Turkey/Version.cs
@@ -11,6 +11,8 @@ namespace Turkey
         public int Minor { get; }
         public string MajorMinor { get; }
 
+        public string Release { get; }
+
         private List<string> parts = null;
 
         public static Version Parse(string input)
@@ -26,9 +28,10 @@ namespace Turkey
             {
                 throw new FormatException();
             }
-            if (parts.Count() == 1)
+            if (parts.Count() <= 2)
             {
-                parts.Add("0");
+                while (parts.Count() <= 2)
+                { parts.Add("0"); }
             }
             int.Parse(parts[0], CultureInfo.InvariantCulture);
             int.Parse(parts[1], CultureInfo.InvariantCulture);
@@ -42,6 +45,21 @@ namespace Turkey
             this.Major = int.Parse(parts[0], CultureInfo.InvariantCulture);
             this.Minor = int.Parse(parts[1], CultureInfo.InvariantCulture);
             this.MajorMinor = this.Major + "." + this.Minor;
+
+            string status = "";
+            if (parts[2].Contains("preview", StringComparison.Ordinal))
+            {
+                status = "preview";
+            }
+            else if (parts[2].Contains("rc", StringComparison.Ordinal))
+            {
+                status = "rc";
+            }
+            else
+            {
+                status = "released";
+            }
+            this.Release = status;
         }
 
         public override string ToString()


### PR DESCRIPTION
Adding a new trait to the test runner that reports whether the version of .NET being tested is a released, preview, rc1 or rc2 version of .NET.
Trait appears in the output as 'status='.

To skip tests using this trait, in the tests JSON file enter: 
status=released
status=preview
status=rc