### PR TITLE
Rename uname log file from "uname" to "uname.log"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,6 @@ jobs:
         run: |
           set -euo pipefail
           cat cpuinfo meminfo os-release
-          cat uname
+          cat uname.log
           cat packages
           find -iname '*.log' -exec echo {} \; -exec cat {} \;

--- a/Turkey/TestRunner.cs
+++ b/Turkey/TestRunner.cs
@@ -178,7 +178,7 @@ namespace Turkey
             }
 
             string unameOutput = ProcessRunner.Run("uname", "-a");
-            File.WriteAllText(Path.Combine(logDir, "uname"), unameOutput);
+            File.WriteAllText(Path.Combine(logDir, "uname.log"), unameOutput);
 
             try
             {


### PR DESCRIPTION
The test runner fails on re-runs due to the presence of the uname log file called "uname" in the working directory. Renaming it to "uname.log" will allow successful re-runs and will still be called in CI.

Closes #98 